### PR TITLE
Add CSV export option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ poetry run twevals run examples --label production --label test
 Control output and speed:
 
 ```bash
-poetry run twevals run examples -c 4 -o results.json -v
-# -c/--concurrency: parallelism, -o: save JSON, -v: print user output
+poetry run twevals run examples -c 4 -o results.json --csv results.csv -v
+# -c/--concurrency: parallelism
+# -o: path to JSON output file
+# --csv/-s: path to CSV output file (include filename)
+# -v: print user output
 ```
 
 ## Minimal Eval (sync)

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -113,6 +113,40 @@ def test_export():
         assert result["result"]["output"] == {"result": "data"}
         assert result["result"]["metadata"] == {"model": "test"}
 
+    def test_csv_export(self, tmp_path):
+        # Create test file
+        test_file = tmp_path / "test_export.py"
+        test_file.write_text("""
+from twevals import eval, EvalResult
+
+@eval()
+def test_export():
+    return EvalResult(
+        input={"key": "value"},
+        output={"result": "data"},
+        scores={"key": "metric", "value": 0.8},
+        metadata={"model": "test"}
+    )
+""")
+
+        # Run with CSV export
+        csv_file = tmp_path / "results.csv"
+        runner = EvalRunner()
+        summary = runner.run(
+            str(test_file),
+            csv_file=str(csv_file)
+        )
+
+        # Verify CSV file was created
+        assert csv_file.exists()
+
+        # Load and verify CSV content
+        with open(csv_file) as f:
+            lines = f.read().strip().splitlines()
+
+        # Header + one result row
+        assert len(lines) == 2
+
     def test_error_handling(self, tmp_path):
         # Create test file with error
         test_file = tmp_path / "test_errors.py"

--- a/twevals/README.md
+++ b/twevals/README.md
@@ -34,12 +34,12 @@ Evaluation execution engine:
 - Support for sequential and concurrent execution
 - Async/sync function handling
 - Result aggregation and summary statistics
-- JSON export functionality
+- JSON and CSV export functionality
 
 ### `cli.py`
 Command-line interface:
 - Main CLI entry point using Click framework
-- `run` command with options for filtering, output, and concurrency
+- `run` command with options for filtering, output (JSON/CSV), and concurrency
 - Progress indicators and status reporting
 - Integration with Rich for beautiful console output
 

--- a/twevals/cli.py
+++ b/twevals/cli.py
@@ -21,7 +21,8 @@ def cli():
 @click.argument('path', type=click.Path(exists=True))
 @click.option('--dataset', '-d', help='Run evaluations for specific dataset(s), comma-separated')
 @click.option('--label', '-l', multiple=True, help='Run evaluations with specific label(s)')
-@click.option('--output', '-o', help='Save results to JSON file')
+@click.option('--output', '-o', type=click.Path(dir_okay=False), help='Path to JSON file for results')
+@click.option('--csv', '-s', type=click.Path(dir_okay=False), help='Path to CSV file for results (include filename)')
 @click.option('--concurrency', '-c', default=0, type=int, help='Number of concurrent evaluations (0 for sequential)')
 @click.option('--verbose', '-v', is_flag=True, help='Show detailed output')
 def run(
@@ -29,6 +30,7 @@ def run(
     dataset: Optional[str],
     label: tuple,
     output: Optional[str],
+    csv: Optional[str],
     concurrency: int,
     verbose: bool
 ):
@@ -48,6 +50,7 @@ def run(
                 dataset=dataset,
                 labels=labels,
                 output_file=output,
+                csv_file=csv,
                 verbose=verbose
             )
         except Exception as e:
@@ -79,6 +82,8 @@ def run(
     # Output file notification
     if output:
         console.print(f"\n[green]Results saved to: {output}[/green]")
+    if csv:
+        console.print(f"[green]Results saved to: {csv}[/green]")
 
 
 def main():


### PR DESCRIPTION
## Summary
- add `--csv` flag to CLI to export evaluation results to CSV alongside JSON
- extend `EvalRunner` with CSV output support
- document CSV export and add tests
- clarify that `--csv` and `--output` expect file paths including filenames

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86611f1008326b5433345988fff5d