### PR TITLE
Move changelog to Mintlify docs

### DIFF
--- a/.claude/commands/deslop-repo.md
+++ b/.claude/commands/deslop-repo.md
@@ -2,7 +2,7 @@ Clean up the EZVals Codebase
 
 I want to clean up tech debt and remove as many lines of code as possible in this codebase. The goal is to simplify the codebase as much as possible while still maintaining the same behavior and performance. The ultimate flex of a good developer is to tell them to download my lib, and its this many lines of code! The behavior right now is great, I just want to simplify the code. I suggest you:
 
-1. Make sure integration tests give you a snapshot of the current public behavior. Crosscheck the @CHANGELOG.md and @README.md to make sure all public features and edge cases mentioned are covered in the integration tests.
+1. Make sure integration tests give you a snapshot of the current public behavior. Crosscheck docs/changelog.mdx and @README.md to make sure all public features and edge cases mentioned are covered in the integration tests.
 2. Remove the bloat code
 3. Run tests to confirm no regressions. 
 

--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -10,7 +10,7 @@ Follow these steps:
 - Read key changed files to understand what was implemented
 - Summarize the features/changes in the branch
 
-## 2. Update CHANGELOG.md
+## 2. Update docs/changelog.mdx
 - Add entries to the "Unreleased" section
 - Use these prefixes:
   - `Added:` for new features

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -15,8 +15,8 @@ Follow these steps in order:
 - Understand what features/fixes/changes are being shipped
 
 
-## 3. Update CHANGELOG.md
-- Add entries to the "Unreleased" section at the top (below "All notable changes...")
+## 3. Update docs/changelog.mdx
+- Add entries to the "Unreleased" section at the top (below the frontmatter)
 - If no "Unreleased" section exists, create one: `## Unreleased`
 - Analyze the git diff to auto-generate changelog entries
 - Use these prefixes based on change type:
@@ -71,8 +71,8 @@ Follow these steps in order:
 **Skip this step unless the user explicitly asked to ship to main.**
 
 If shipping to main:
-1. Don't ask the user what version number to use (suggest next alpha based on CHANGELOG)
-2. Update CHANGELOG.md: change `## Unreleased` to `## <version> - <today's date>`
+1. Don't ask the user what version number to use (suggest next alpha based on docs/changelog.mdx)
+2. Update docs/changelog.mdx: change `## Unreleased` to `## <version> - <today's date>`
 3. Update `pyproject.toml` version to match
 4. Commit: `git commit -m "release <version>"`
 5. Push dev: `git push origin dev`

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,6 +1,7 @@
-Changelog
-
-All notable changes to this project will be documented in this file.
+---
+title: "Changelog"
+description: "All notable changes to EZVals"
+---
 
 ## Unreleased
 
@@ -19,7 +20,7 @@ All notable changes to this project will be documented in this file.
 - Added: Markdown export with stats visualization and filtered data support.
 - Added: Export dropdown menu in header with JSON, CSV, and Markdown formats.
 - Added: `ezvals export` CLI command for exporting runs to JSON, CSV, or Markdown.
-- Added: Markdown export includes ASCII progress bars with color emoji indicators (🟢🟡🔴).
+- Added: Markdown export includes ASCII progress bars with color emoji indicators.
 - Added: Filtered Markdown export respects current filters and column visibility.
 - Added: Comparison mode for viewing 2-4 runs side-by-side. Click "+ Compare" in stats bar to select runs, view grouped bar charts with color-coded metrics, and compare outputs across runs in a unified table with per-run columns.
 - Added: `GET /api/runs/{run_id}/data` endpoint for fetching run data without changing the active run.
@@ -172,13 +173,13 @@ All notable changes to this project will be documented in this file.
 - Added: Timeout support for target hooks with proper error handling and latency tracking on timeout.
 - Tests: Added comprehensive timeout tests covering async/sync functions and target hooks.
 
-0.0.2a8 - 2025-11-23
+## 0.0.2a8 - 2025-11-23
 
 - Added: `--list` flag to `ezvals run` command to list evaluations without running them, preserving all filtering options.
 - Changed: Removed standalone `list` command in favor of `run --list`.
 - Tests: Added regression test for concurrency output capturing.
 
-0.0.2a7 - 2025-11-23
+## 0.0.2a7 - 2025-11-23
 
 - Added: File-level defaults via `ezvals_defaults` dictionary - set global properties (dataset, labels, metadata, etc.) at the top of test files that all tests inherit, similar to pytest's pytestmark pattern.
 - Added: Support for all decorator parameters in file defaults including evaluators, target, input, reference, default_score_key, metadata, and metadata_from_params.
@@ -188,7 +189,7 @@ All notable changes to this project will be documented in this file.
 - Changed: `default_score_key` parameter default changed from "correctness" to None to enable file-level defaults, with "correctness" still applied as final fallback via EvalContext.
 - Tests: Added 17 comprehensive tests for file defaults including inheritance, overrides, deep merge, mutable value copying, and default_score_key priority chain.
 
-0.0.2a6 - 2025-11-23
+## 0.0.2a6 - 2025-11-23
 
 - Added: `target` parameter to `@eval` decorator allowing pre-hook functions that run before the evaluation function, enabling separation of agent/LLM invocation from evaluation logic.
 - Added: Target hooks receive `EvalContext` and can populate output, metadata, and custom attributes before the eval function executes.
@@ -198,7 +199,7 @@ All notable changes to this project will be documented in this file.
 - Changed: Parametrize now defaults `ctx.input` to parametrized values when no explicit input is provided, making param data accessible to targets.
 - Tests: Added comprehensive unit tests for target functionality including output injection, error handling, async support, and parametrize integration.
 
-0.0.2a5 - 2025-11-22
+## 0.0.2a5 - 2025-11-22
 
 - Added: `--json` flag for `ezvals run` command to output results as compact JSON to stdout, omitting null values for machine-readable output.
 - Added: Pytest-style progress reporting during evaluation execution with colored output (green for pass, red for fail/error).
@@ -209,12 +210,12 @@ All notable changes to this project will be documented in this file.
 - Tests: Added comprehensive tests for progress reporting hooks and CLI progress output validation.
 - Tests: Added tests for `--json` flag output format validation and null value omission.
 
-0.0.2a4 - 2025-11-22
+## 0.0.2a4 - 2025-11-22
 
 - Added: Function name filtering using `file.py::function_name` syntax, similar to pytest. Run specific evaluation functions or parametrized variants (e.g., `ezvals run tests.py::my_eval` or `tests.py::my_eval[param1]`).
 - Tests: Added comprehensive tests for function filtering including exact matches, parametrized variants, and combined filters with dataset/labels.
 
-0.0.2a3 - 2025-11-22
+## 0.0.2a3 - 2025-11-22
 
 - Fixed: `add_output()` now correctly handles dicts without EvalResult fields (like `{'full_name': 'Kim Diaz'}`) by storing them as-is in the output field, instead of incorrectly treating them as structured EvalResult dicts.
 - Fixed: Eval results table now preserves source file order instead of alphabetically sorting functions by name (resolves #2).
@@ -224,18 +225,18 @@ All notable changes to this project will be documented in this file.
 - Tests: Added comprehensive tests for `add_output()` behavior with arbitrary dict structures to prevent regression.
 - Tests: Added test to verify source file order preservation in discovery.
 
-0.0.2a2 - 2025-11-22
+## 0.0.2a2 - 2025-11-22
 
 - Fixed: Failed assertions now create failing scores instead of error states, properly treating them as validation failures rather than execution errors.
 - Fixed: Output field is now preserved in results table when assertions fail, instead of being overwritten with error messages.
 - Changed: Table formatter only displays error in output column when output is empty, preventing loss of actual output data.
 - Tests: Added comprehensive tests for assertion handling including edge cases for assertions without messages, non-assertion errors, and multiple assertions.
 
-0.0.2a1 - 2025-11-22
+## 0.0.2a1 - 2025-11-22
 
 - Fixed: Module discovery now properly handles relative imports by temporarily adding parent directory to sys.path with cleanup.
 
-0.0.2a0 - 2025-11-22
+## 0.0.2a0 - 2025-11-22
 
 - Added: `EvalContext` (accessible as `ctx`, `context`, or `carrier` parameter) provides a mutable builder pattern for constructing eval results incrementally with methods like `add_output()`, `add_score()`, and `set_params()`.
 - Added: Context manager support for `EvalContext` allowing `with` statement usage in eval functions.
@@ -255,15 +256,15 @@ All notable changes to this project will be documented in this file.
 - Tests: Added integration tests for context usage patterns, parametrize auto-mapping, and assertion preservation.
 - Tests: Added e2e test for advanced UI filters functionality.
 
-0.0.1a0 - 2025-09-04
+## 0.0.1a0 - 2025-09-04
 
-- Added: Results Web UI with expandable rows, multi‑column sorting, column toggles and resizable columns, copy‑to‑clipboard, and summary chips for score ratios/averages.
-- Added: Inline editing in the UI for dataset, labels, metadata (JSON), scores (key/value/passed/notes), and a free‑form annotation. Edits are persisted to JSON.
+- Added: Results Web UI with expandable rows, multi-column sorting, column toggles and resizable columns, copy-to-clipboard, and summary chips for score ratios/averages.
+- Added: Inline editing in the UI for dataset, labels, metadata (JSON), scores (key/value/passed/notes), and a free-form annotation. Edits are persisted to JSON.
 - Added: Actions menu in the UI with Refresh, Rerun full suite, Export JSON, and Export CSV.
 - Added: Server endpoints: `PATCH /api/runs/{run_id}/results/{index}` for updates; `POST /api/runs/rerun`; `GET /api/runs/{run_id}/export/{json|csv}`.
-- Added: `ezvals serve --dev` hot‑reload mode for rapid UI/eval iteration.
+- Added: `ezvals serve --dev` hot-reload mode for rapid UI/eval iteration.
 - Added: CLI CSV export via `ezvals run ... --csv results.csv` (in addition to JSON `-o`).
 - Added: `ResultsStore` for robust, atomic JSON writes under `.ezvals/runs/` with `latest.json` convenience copy.
-- Added: `EvalResult.run_data` for run‑specific structured data, displayed in the UI details panel.
+- Added: `EvalResult.run_data` for run-specific structured data, displayed in the UI details panel.
 - Changed: CLI `run` prints a results table by default and a concise summary below it.
 - Tests: Added integration tests for server (JSON flow, export endpoints, rerun) and e2e UI tests (Playwright), plus unit tests for storage behavior.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -71,6 +71,10 @@
         "api-reference/eval-result",
         "api-reference/score"
       ]
+    },
+    {
+      "group": "Resources",
+      "pages": ["changelog"]
     }
   ],
   "footerSocials": {


### PR DESCRIPTION
Move the changelog from the root CHANGELOG.md to docs/changelog.mdx as a single source of truth published to Mintlify. Updated all slash commands (/ship, /prepare-merge, /deslop-repo) to reference the new location. Added changelog link to navigation in mint.json.