### PR TITLE
Auto-resolve port conflicts in ezvals serve

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "ezvals"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
When a port is already in use, automatically find the next available port and inform the user clearly. Supports trying up to 10 consecutive ports before failing. Improves UX when multiple instances of ezvals serve are run on the same machine.