### PR TITLE
Export EvalCase TypedDict and simplify docs

### DIFF
--- a/ezvals/__init__.py
+++ b/ezvals/__init__.py
@@ -2,8 +2,9 @@ from ezvals.decorators import eval
 from ezvals.schemas import EvalResult, TraceData
 from ezvals.context import EvalContext
 from ezvals.runner import run_evals
+from ezvals.types import EvalCase
 
-__all__ = ["eval", "EvalResult", "TraceData", "EvalContext", "run_evals"]
+__all__ = ["eval", "EvalResult", "TraceData", "EvalContext", "run_evals", "EvalCase"]
 
 # Resolve version from installed package metadata to avoid hard-coding.
 try:  # Python 3.8+

--- a/ezvals/cases.py
+++ b/ezvals/cases.py
@@ -1,26 +1,17 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, get_type_hints
 import inspect
 
 from ezvals.decorators import EvalFunction
 from ezvals.context import EvalContext
+from ezvals.types import EvalCase
+
+# Derive allowed case keys from EvalCase TypedDict (excludes 'id' which is handled separately)
+RESERVED_CASE_KEYS = set(get_type_hints(EvalCase).keys()) - {"id"}
 
 
-RESERVED_CASE_KEYS = {
-    "input",
-    "reference",
-    "metadata",
-    "dataset",
-    "labels",
-    "default_score_key",
-    "timeout",
-    "target",
-    "evaluators",
-}
-
-
-def _normalize_cases(cases: Any) -> Tuple[List[Dict[str, Any]], List[Optional[str]]]:
+def _normalize_cases(cases: List[EvalCase]) -> Tuple[List[Dict[str, Any]], List[Optional[str]]]:
     if not isinstance(cases, (list, tuple)):
         raise ValueError("cases must be a list of dicts")
 
@@ -44,7 +35,7 @@ def _normalize_cases(cases: Any) -> Tuple[List[Dict[str, Any]], List[Optional[st
     return case_sets, case_ids
 
 
-def apply_cases(func: Callable, cases: Any) -> Callable:
+def apply_cases(func: Callable, cases: List[EvalCase]) -> Callable:
     if cases is None:
         return func
     case_sets, case_ids = _normalize_cases(cases)

--- a/ezvals/types.py
+++ b/ezvals/types.py
@@ -1,0 +1,30 @@
+"""Type definitions for ezvals."""
+
+from typing import Any, Callable, Dict, List
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
+
+
+class EvalCase(TypedDict, total=False):
+    """Schema for items in the @eval(cases=[...]) array.
+
+    All fields are optional. Most fields match the @eval decorator parameters
+    and override the decorator-level values for that specific case.
+    """
+
+    # Case-specific field (not available on decorator)
+    id: str  # Test case identifier, used in function name: func[id]
+
+    # Fields matching @eval decorator params (override per-case)
+    input: Any
+    reference: Any
+    metadata: Dict[str, Any]
+    dataset: str
+    labels: List[str]
+    default_score_key: str
+    timeout: float
+    target: Callable
+    evaluators: List[Callable]


### PR DESCRIPTION
Exports a new `EvalCase` TypedDict that describes the schema for items in the `@eval(cases=[...])` array. Since case items use the same parameters as the `@eval` decorator (minus `cases` and `input_loader`, plus `id`), `RESERVED_CASE_KEYS` is now derived from the TypedDict to avoid duplication and keep them in sync.

Updated documentation to deduplicate parameter descriptions by adding a "Per-case?" column to the decorator params table and referencing it from the cases section. This makes it clear which params can be overridden per-case without repeating the full parameter list.

All 328 tests pass.