### PR TITLE
Document skill version checks in release guides

### DIFF
--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -37,7 +37,13 @@ Review if changes require updates to:
 
 When updating, write docs as if they're the current state - don't mention "updated" or "changed from".
 
-## 4. Summary
+## 4. Check Skill Version (If Merging to Main)
+If preparing for a release to main:
+- Check the version in `ezvals/skills/evals/SKILL.md` (the `<!-- Version: X.X.X -->` line)
+- Flag if it doesn't match the upcoming release version
+- The Sync Skill to Marketplace CI workflow requires the skill version to match the release tag
+
+## 5. Summary
 Report:
 - What features/changes were found
 - What documentation was updated

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -70,12 +70,9 @@ Follow these steps in order:
 
 **Only do this when shipping to main (creating a release):**
 
-If the release includes changes that affect the skill content:
-- Update the version comment in `ezvals/skills/evals/SKILL.md` (the `<!-- Version: X.X.X -->` line)
-- Ensure examples and CLI commands in the skill are current
-- Run `ezvals skills doctor` to verify skill is valid
-
-The skill version MUST match the release tag for the sync workflow to pass.
+- **Always** update the version comment in `ezvals/skills/evals/SKILL.md` (the `<!-- Version: X.X.X -->` line) to match the release version
+- The skill version **MUST** match the release tag — the Sync Skill to Marketplace workflow will fail otherwise
+- If the release includes changes that affect the skill content, also ensure examples and CLI commands in the skill are current
 
 ## 7. Ship to Main (Only If Requested)
 


### PR DESCRIPTION
Summary
- clarify that prerelease merge prep should verify the version comment in `ezvals/skills/evals/SKILL.md` matches upcoming release versions
- emphasize in the ship checklist that the skill version must match the release tag and update examples/commands when the skill changes

Testing
- Not run (not requested)