### PR TITLE
restructure docs for AI-first audience

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -1,0 +1,157 @@
+---
+title: Architecture
+description: How EZVals is structured and how the pieces fit together
+---
+
+EZVals has a small number of components that work together. Understanding the architecture helps you reason about what's happening when evals run, and helps you communicate more effectively with your coding agent about what you want.
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Your Project                       │
+│                                                      │
+│  ┌──────────┐    ┌──────────┐    ┌──────────────┐   │
+│  │ evals.py │    │ evals/   │    │ ezvals.json  │   │
+│  │          │    │  ├ qa.py  │    │ (config)     │   │
+│  │ @eval()  │    │  ├ rag.py │    └──────────────┘   │
+│  └────┬─────┘    └────┬─────┘                        │
+│       └───────┬───────┘                              │
+│               ▼                                      │
+│  ┌─────────────────────────────────────────────┐     │
+│  │            EZVals Runtime                    │     │
+│  │                                             │     │
+│  │  Discovery → Execution → Scoring → Storage  │     │
+│  └──────────┬──────────────────────┬───────────┘     │
+│             │                      │                 │
+│    ┌────────▼────────┐   ┌────────▼────────┐        │
+│    │   Web UI (:8000)│   │  CLI (stdout)   │        │
+│    │   ezvals serve  │   │  ezvals run     │        │
+│    │                 │   │                 │        │
+│    │  For humans     │   │  For agents     │        │
+│    └─────────────────┘   └─────────────────┘        │
+│                                                      │
+│  ┌─────────────────────────────────────────────┐     │
+│  │  .ezvals/runs/                              │     │
+│  │  └ results stored as JSON                   │     │
+│  └─────────────────────────────────────────────┘     │
+└─────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### Eval Files
+
+Eval files are regular Python files that contain functions decorated with `@eval`. Each decorated function is one evaluation. These files live in your project alongside your application code — they're version-controlled, branch-able, and diff-able.
+
+You can organize evals however you want: a single file, a directory of files grouped by feature, or any structure that makes sense for your project.
+
+### The Runtime
+
+When you run `ezvals serve` or `ezvals run`, EZVals:
+
+1. **Discovers** all `@eval`-decorated functions in the specified files
+2. **Executes** each eval function (with optional concurrency)
+3. **Scores** the results using assertions, `store()` calls, or evaluator functions
+4. **Stores** the results as JSON in `.ezvals/runs/`
+
+The runtime handles error catching, latency tracking, timeout enforcement, and result serialization automatically.
+
+### Two Interfaces
+
+EZVals provides two ways to interact with the same underlying system:
+
+| | Web UI (`serve`) | CLI (`run`) |
+|---|---|---|
+| **Audience** | You (the developer) | Your coding agent |
+| **Interaction** | Visual dashboard in browser | Structured output to stdout |
+| **Best for** | Reviewing results, comparing runs, deep analysis | Running evals programmatically, CI/CD |
+| **Run control** | Click to run, filter, rerun individual evals | Command flags for filtering and execution |
+
+Both interfaces read from and write to the same result files, so you can run evals with your agent via CLI and then review the results in the Web UI.
+
+### Results Storage
+
+All results are stored as JSON files in `.ezvals/runs/`. Each run produces a file like:
+
+```
+.ezvals/runs/cool-cloud-2025-01-15T10-30-00.json
+```
+
+These files contain everything: inputs, outputs, scores, latency, metadata, and errors. Because they're just JSON files in your repo, you can:
+
+- Compare runs over time
+- Track them in version control (or gitignore them)
+- Parse them with any tool
+- Share them with your team
+
+### Sessions
+
+Sessions group related runs together. When you're iterating on something — comparing models, tuning prompts, or testing different approaches — sessions let you track the progression:
+
+```bash
+# First run
+ezvals serve evals.py --session prompt-tuning --run-name v1
+
+# After making changes
+ezvals serve evals.py --session prompt-tuning --run-name v2
+```
+
+The Web UI shows all runs in a session together, making it easy to compare results side-by-side.
+
+## The Agent Skill
+
+The agent skill is a set of markdown files installed into your project that teach your coding agent how to work with EZVals. It includes:
+
+- API reference and patterns
+- Best practices for eval design
+- Grading strategies
+- Agent-specific eval patterns
+
+When the skill is installed, your agent doesn't need to read these docs — it has everything it needs to write, run, and iterate on evals autonomously.
+
+```bash
+ezvals skills add
+```
+
+This creates skill files in agent-specific directories (`.claude/skills/`, `.cursor/skills/`, etc.) that your agent picks up automatically.
+
+## Data Flow
+
+Here's what happens when an eval runs:
+
+```
+@eval decorator
+  │
+  ├─ Reads: input, reference, dataset, labels, cases
+  │
+  ▼
+Target function (optional)
+  │
+  ├─ Calls your agent/LLM/API
+  ├─ Sets ctx.output
+  │
+  ▼
+Eval function
+  │
+  ├─ Runs assertions → scores
+  ├─ Calls ctx.store() → scores
+  │
+  ▼
+Evaluators (optional, post-processing)
+  │
+  ├─ Runs each evaluator on the result
+  ├─ Adds additional scores
+  │
+  ▼
+EvalResult
+  │
+  ├─ input, output, reference
+  ├─ scores[], error, latency
+  ├─ metadata
+  │
+  ▼
+JSON file in .ezvals/runs/
+```
+
+Each step is optional except the eval function itself. A minimal eval is just a decorated function with an assertion. A full eval might include a shared target, multiple scoring approaches, and post-processing evaluators.

--- a/docs/concepts/evaluation-best-practices.mdx
+++ b/docs/concepts/evaluation-best-practices.mdx
@@ -1,0 +1,132 @@
+---
+title: Evaluation Best Practices
+description: How to think about evaluating LLMs and AI agents
+---
+
+Evaluating LLMs and agents is fundamentally different from testing traditional software. Functions are deterministic — LLMs are not. This page covers the mental models and strategies that lead to effective evaluations.
+
+## Why Evaluate?
+
+Without evals, you're relying on vibes. You make a change to a prompt or model, manually test a few inputs, and hope for the best. Evals give you:
+
+- **Confidence that changes don't break things** — Regression detection across a dataset of inputs
+- **Measurable progress** — Track scores over time as you iterate on prompts, models, or architectures
+- **Objective comparison** — Compare models, prompts, or approaches side-by-side with data instead of gut feel
+
+## Key Principles
+
+### 1. Eval What Matters to Users
+
+Start with the behaviors your users care about. If you're building a customer support agent, the evals that matter are:
+
+- Does it correctly identify the customer's issue?
+- Does it follow your company's policies?
+- Is the response helpful and empathetic?
+
+These are more useful than generic "is the output grammatically correct?" checks. Work backwards from user experience to eval criteria.
+
+### 2. Start Simple, Add Complexity Later
+
+Your first eval should be a simple assertion:
+
+```python
+assert "refund" in ctx.output.lower(), "Should mention refund process"
+```
+
+Don't start with LLM-as-judge, semantic similarity, or complex scoring rubrics. Simple checks catch a surprising number of regressions and give you a baseline to improve from.
+
+### 3. Use a Mix of Scoring Approaches
+
+Different aspects of quality need different measurement tools:
+
+| What you're checking | Approach |
+|---|---|
+| Output contains required information | Assertions (`assert "X" in output`) |
+| Output matches expected format | Code-based validation (JSON parsing, regex) |
+| Output is semantically similar to reference | Embedding similarity scores |
+| Output quality is subjective | LLM-as-judge evaluators |
+| Output correctness requires domain expertise | Human review (via the Web UI) |
+
+Most eval suites end up using a combination. Start with assertions and code checks, then layer in model-based and human evaluation as needed.
+
+### 4. Build a Representative Dataset
+
+Your test cases should cover:
+
+- **Happy paths** — Common, well-formed inputs
+- **Edge cases** — Unusual inputs, ambiguous queries, adversarial prompts
+- **Failure modes** — Inputs that previously caused problems
+- **Distribution** — A mix that roughly matches real-world usage
+
+You don't need hundreds of cases upfront. Start with 5-10 good examples and grow your dataset as you find new failure modes.
+
+### 5. Track Runs Over Time
+
+A single eval run tells you where you are. Multiple runs tell you if you're improving. Use sessions to track iterations:
+
+```bash
+ezvals serve evals.py --session prompt-v2 --run-name before-changes
+# ... make changes ...
+ezvals serve evals.py --session prompt-v2 --run-name after-changes
+```
+
+The Web UI's comparison mode makes it easy to see exactly what changed between runs.
+
+## Grading Strategies
+
+### Code-Based Grading
+
+Use code to check things that have objectively correct answers:
+
+- String matching and containment
+- JSON structure validation
+- Numeric range checks
+- Regex pattern matching
+- API response format verification
+
+Code graders are fast, deterministic, and free. Use them whenever possible.
+
+### Model-Based Grading (LLM-as-Judge)
+
+Use another LLM to evaluate the output when the quality criteria are subjective or complex:
+
+- Is the explanation clear and accurate?
+- Does the response follow the specified tone?
+- Is the summary faithful to the source material?
+
+Model-based grading introduces its own variability, so use it for criteria that genuinely require judgment rather than for things you could check with code.
+
+### Human Review
+
+Use the Web UI for manual review when:
+
+- You're bootstrapping a new eval and don't know what "good" looks like yet
+- The quality criteria are too nuanced for automated grading
+- You want to annotate results to build a training dataset for model-based graders
+
+EZVals makes this easy with inline editing, annotation support, and export to JSON/CSV.
+
+## Common Pitfalls
+
+<AccordionGroup>
+  <Accordion title="Testing the model instead of your system">
+    Your eval should test your agent/application behavior, not the underlying LLM's raw capability. If you swap models and scores drop, that's useful signal. But write evals that test the full pipeline — prompts, retrieval, processing, and output formatting included.
+  </Accordion>
+  <Accordion title="Overfitting evals to current behavior">
+    If your evals are so specific that any change to the model or prompt breaks them, they're too brittle. Test for the criteria that matter (correctness, helpfulness, safety) rather than exact output matches.
+  </Accordion>
+  <Accordion title="Ignoring latency and cost">
+    EZVals tracks latency automatically. If your agent takes 30 seconds to respond, that's relevant even if the output is perfect. Consider adding latency-based scoring to your evals.
+  </Accordion>
+  <Accordion title="Not testing failure modes">
+    LLMs fail in predictable ways — hallucination, instruction ignoring, safety refusals, format violations. Include test cases that specifically probe these failure modes.
+  </Accordion>
+</AccordionGroup>
+
+## Recommended Reading
+
+These resources informed EZVals' design and are useful for building an eval mindset:
+
+- **Anthropic's guide to evals** — Practical guidance on evaluation design from the Claude team
+- **OpenAI's eval framework philosophy** — How to think about testing LLM applications at scale
+- **Hamel Husain's "Your AI Product Needs Evals"** — A practical framework for product-oriented evaluation

--- a/docs/concepts/workflow.mdx
+++ b/docs/concepts/workflow.mdx
@@ -1,0 +1,159 @@
+---
+title: The Evaluation Loop
+description: The evaluate → analyze → iterate workflow
+---
+
+EZVals is built around a continuous loop: write evals, run them, analyze results, make changes, and run again. This page explains that workflow and how the different pieces of EZVals support each stage.
+
+## The Loop
+
+```
+    ┌─────────────────────────────────────────┐
+    │                                         │
+    ▼                                         │
+┌────────┐    ┌────────┐    ┌─────────┐    ┌──┴───┐
+│ Define │───▶│  Run   │───▶│ Analyze │───▶│Iterate│
+└────────┘    └────────┘    └─────────┘    └───────┘
+```
+
+### 1. Define
+
+Decide what you want to evaluate and write (or have your agent write) the eval code.
+
+**Who does this:** You define what to test. Your coding agent writes the eval functions.
+
+```
+You: "Write evals for my customer support agent — test that it correctly
+      handles refund requests, billing questions, and escalation to humans"
+
+Agent: Creates evals.py with @eval-decorated functions, test cases, and assertions
+```
+
+The eval file lives in your repo alongside your application code. Your agent uses the EZVals skill to understand the framework's API and patterns.
+
+### 2. Run
+
+Execute the evals to get results.
+
+**From the Web UI** (you):
+```bash
+ezvals serve evals.py
+```
+Click "Run All" or run individual evals from the dashboard. See results populate in real time.
+
+**From the CLI** (your agent):
+```bash
+ezvals run evals.py --session refund-testing --run-name v1
+```
+Results go to stdout and are saved as JSON for analysis.
+
+### 3. Analyze
+
+Review the results to understand what's working and what isn't.
+
+**In the Web UI:** Browse the results table, click into individual results to see full input/output/scores, use filters to focus on failures, and compare runs side-by-side.
+
+**With your agent:** The agent reads the JSON results and provides analysis:
+
+```
+You: "Run the refund evals and tell me what's failing"
+
+Agent: Runs the evals, reads the results JSON, and reports:
+       "3 of 8 refund evals failed. The agent isn't mentioning the
+        7-day return window in cases where the purchase is recent.
+        The billing evals all pass."
+```
+
+### 4. Iterate
+
+Make changes based on the analysis and run again.
+
+This is where the loop closes. Based on what you learned:
+
+- **Improve your agent** — Update prompts, fix retrieval, adjust system messages
+- **Improve your evals** — Add edge cases you discovered, refine scoring criteria
+- **Compare before/after** — Use sessions to track whether changes helped
+
+```
+You: "Fix the refund response to mention the 7-day window, then rerun"
+
+Agent: Updates the prompt, reruns evals:
+       "All 8 refund evals now pass. The billing evals still pass too —
+        no regressions."
+```
+
+## Session Workflow
+
+Sessions make the iteration loop concrete by grouping related runs:
+
+```bash
+# Baseline
+ezvals run evals.py --session prompt-tuning --run-name baseline
+
+# After prompt changes
+ezvals run evals.py --session prompt-tuning --run-name v2-with-examples
+
+# After model swap
+ezvals run evals.py --session prompt-tuning --run-name v3-claude-sonnet
+```
+
+Open the Web UI to compare all three runs side-by-side and see exactly which evals improved, regressed, or stayed the same.
+
+## Who Does What
+
+The division of labor between you and your coding agent:
+
+| Task | You | Your Agent |
+|---|---|---|
+| Decide what to evaluate | Describe the behaviors that matter | |
+| Write eval code | | Writes `@eval` functions, cases, assertions |
+| Run evals (interactive) | Click "Run" in Web UI | |
+| Run evals (programmatic) | | `ezvals run` from CLI |
+| Review results visually | Browse the dashboard | |
+| Analyze failures | | Reads JSON, identifies patterns |
+| Fix issues | Approve changes | Modifies code, prompts, configs |
+| Compare runs | View side-by-side in Web UI | |
+| Track progress | Review session history | |
+
+This division lets you stay focused on the high-level questions — "Is my agent behaving correctly?" — while your coding agent handles the mechanical work of writing eval code, running tests, and diagnosing failures.
+
+## Workflow Examples
+
+### Prompt Iteration
+
+```
+You: "My support agent is too verbose. Write evals that check response length
+      and conciseness, then help me iterate on the system prompt."
+
+Agent: 1. Writes evals with length assertions and brevity scoring
+       2. Runs baseline evals
+       3. Reports: "Average response is 450 words. 6/10 exceed 300 words."
+       4. Suggests prompt changes
+       5. Reruns evals after changes
+       6. Reports: "Average response is now 180 words. All pass brevity check."
+```
+
+### Model Comparison
+
+```
+You: "I want to compare GPT-4o and Claude Sonnet on our customer service evals"
+
+Agent: 1. Writes evals with cases parameterized by model
+       2. Runs with --session model-comparison --run-name gpt4o
+       3. Runs with --session model-comparison --run-name claude-sonnet
+       4. Reports comparison results
+
+You: Open Web UI → compare runs side-by-side
+```
+
+### Regression Testing
+
+```
+You: "I'm about to change the retrieval pipeline. Run the full eval suite
+      before and after so we can compare."
+
+Agent: 1. Runs ezvals run evals/ --session retrieval-change --run-name before
+       2. You make the pipeline changes
+       3. Runs ezvals run evals/ --session retrieval-change --run-name after
+       4. Reports: "2 regressions in RAG evals, 1 improvement in latency"
+```

--- a/docs/guides/sessions.mdx
+++ b/docs/guides/sessions.mdx
@@ -1,95 +1,74 @@
 ---
 title: Sessions & Runs
-description: Group related evaluation runs together for comparison and tracking
+description: Track iterations and compare results over time
 ---
 
-Sessions let you group related evaluation runs together, enabling workflows like model comparison, iterative debugging, and tracking progress over time.
+Sessions group related evaluation runs together. Use them when you're iterating on something and want to compare before/after results.
 
-## Quick Start
+## Basic Usage
 
 ```bash
-# Start the web UI
-ezvals serve evals.py
+# First run — establish a baseline
+ezvals run evals.py --session prompt-tuning --run-name baseline
 
-# Run headlessly with session and run names
-ezvals run evals.py --session model-upgrade --run-name gpt5-baseline
+# Make changes to your agent/prompts, then run again
+ezvals run evals.py --session prompt-tuning --run-name v2-with-examples
 
-# Continue the session with another run
-ezvals run evals.py --session model-upgrade --run-name gpt5-tuned
-
-# Auto-generated friendly names
-ezvals run evals.py
+# Or run from the Web UI with session tracking
+ezvals serve evals.py --session prompt-tuning --run-name v3-refined
 ```
 
-## Concepts
+Sessions are identified by name. Using the same `--session` value continues the session automatically — no setup needed.
 
-### Session
+## How It Works
 
-A **session** groups related runs together, identified by a name string. Using `--session model-upgrade` again continues the same session—runs are linked by matching session names.
-
-### Run
-
-A **run** is a single execution of your evaluations. Each run creates a new JSON file containing only the evals that ran in that execution.
-
-### Auto-Generated Names
-
-When you don't specify `--session` or `--run-name`, friendly adjective-noun names are generated automatically:
-
-- `swift-falcon`
-- `bright-flame`  
-- `gentle-whisper`
-
-This ensures every run has identifiable names without requiring manual input.
-
-## File Naming
-
-Run files are named with the pattern `{run_name}_{timestamp}.json`:
+Each run creates a JSON file in `.ezvals/runs/`:
 
 ```
 .ezvals/runs/
-├── gpt5-baseline_2024-01-15T10-30-00Z.json   # Named run
-├── gpt5-tuned_2024-01-15T11-00-00Z.json      # Second run in session
-├── swift-falcon_2024-01-15T14-45-00Z.json    # Auto-generated name
-└── latest.json                                # Copy of most recent
+├── baseline_2024-01-15T10-30-00Z.json
+├── v2-with-examples_2024-01-15T11-00-00Z.json
+├── v3-refined_2024-01-15T14-45-00Z.json
+└── latest.json
 ```
 
-## JSON Schema
+The session name is stored inside each file, linking runs together. There's no separate session file — sessions are virtual groupings.
 
-Each run file includes session metadata at the top level:
+## Auto-Generated Names
 
-```json
-{
-  "session_name": "model-upgrade",
-  "run_name": "gpt5-baseline",
-  "run_id": "2024-01-15T10-30-00Z",
-  "total_evaluations": 50,
-  "total_passed": 45,
-  "total_errors": 2,
-  "results": [...]
-}
+When you don't specify names, friendly identifiers are generated automatically:
+
+```bash
+ezvals run evals.py
+# Creates: swift-falcon_2024-01-15T14-45-00Z.json
 ```
 
-## UI Display
+This ensures every run is identifiable without requiring manual input.
 
-The stats bar shows the current session and run:
+## Comparing Runs in the Web UI
 
-```
-SESSION model-upgrade · RUN gpt5-baseline | TESTS 50 | ACCURACY 45/50 | ...
-```
+The real power of sessions is in the Web UI's comparison mode:
 
-## Use Cases
+1. Open the Web UI with a session that has multiple runs
+2. Click **+ Compare** in the stats bar
+3. Select runs to compare (up to 4)
+4. View side-by-side results with color-coded metrics
+
+The comparison view aligns results by function name and dataset, making it easy to spot what improved, what regressed, and what stayed the same.
+
+## Common Workflows
 
 <AccordionGroup>
   <Accordion title="Model Comparison">
-    Compare performance across different models or configurations:
+    Compare different models on the same eval suite:
 
     ```bash
-    ezvals run evals/ --session model-comparison --run-name gpt4-baseline
-    ezvals run evals/ --session model-comparison --run-name claude-3
+    ezvals run evals/ --session model-comparison --run-name gpt4o
+    ezvals run evals/ --session model-comparison --run-name claude-sonnet
     ezvals run evals/ --session model-comparison --run-name gemini-pro
     ```
 
-    Each run's JSON file contains the full results for that model, all grouped under the same session.
+    Open the Web UI to compare all three side-by-side.
   </Accordion>
 
   <Accordion title="Iterative Development">
@@ -97,92 +76,38 @@ SESSION model-upgrade · RUN gpt5-baseline | TESTS 50 | ACCURACY 45/50 | ...
 
     ```bash
     ezvals run evals/ --session bug-fix-123 --run-name initial
-    # Make changes...
+    # Fix the issue...
     ezvals run evals/ --session bug-fix-123 --run-name attempt-2
-    # More changes...
+    # More refinement...
     ezvals run evals/ --session bug-fix-123 --run-name fixed
     ```
   </Accordion>
 
   <Accordion title="CI/CD Integration">
-    Use session names to track runs across deployments:
+    Track runs across deployments:
 
     ```bash
     ezvals run evals/ --session "release-${VERSION}" --run-name "build-${BUILD_ID}" -o results.json
     ```
   </Accordion>
 
-  <Accordion title="A/B Testing">
-    Compare different approaches:
+  <Accordion title="A/B Testing Prompts">
+    Compare different prompt strategies:
 
     ```bash
-    ezvals run evals/ --session prompt-experiment --run-name prompt-v1
-    ezvals run evals/ --session prompt-experiment --run-name prompt-v2-concise
-    ezvals run evals/ --session prompt-experiment --run-name prompt-v3-detailed
+    ezvals run evals/ --session prompt-experiment --run-name concise-prompt
+    ezvals run evals/ --session prompt-experiment --run-name detailed-prompt
+    ezvals run evals/ --session prompt-experiment --run-name few-shot-prompt
     ```
   </Accordion>
 </AccordionGroup>
 
-## API Endpoints
-
-When running in serve mode, these endpoints are available for programmatic access:
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/sessions` | GET | List all unique session names |
-| `/api/sessions/{name}/runs` | GET | List runs for a specific session |
-| `/api/runs/{run_id}` | PATCH | Update run metadata (e.g., rename) |
-
-### Example: List Sessions
-
-```bash
-curl http://localhost:8000/api/sessions
-```
-
-```json
-{
-  "sessions": ["model-upgrade", "bug-fix-123", "prompt-experiment"]
-}
-```
-
-### Example: List Runs in Session
-
-```bash
-curl http://localhost:8000/api/sessions/model-upgrade/runs
-```
-
-```json
-{
-  "session_name": "model-upgrade",
-  "runs": [
-    {
-      "run_id": "2024-01-15T11-00-00Z",
-      "run_name": "gpt5-tuned",
-      "total_evaluations": 50,
-      "total_passed": 48,
-      "total_errors": 0
-    },
-    {
-      "run_id": "2024-01-15T10-30-00Z", 
-      "run_name": "gpt5-baseline",
-      "total_evaluations": 50,
-      "total_passed": 45,
-      "total_errors": 2
-    }
-  ]
-}
-```
-
-## Best Practices
+## Tips
 
 <Note>
-**Naming Conventions**: Use descriptive session names that indicate the purpose (e.g., `model-comparison`, `bug-fix-123`, `release-v2.0`). Run names should describe what's different about that specific run.
+Use descriptive session names that indicate the purpose (e.g., `model-comparison`, `bug-fix-123`, `release-v2.0`). Run names should describe what's different about that specific run.
 </Note>
 
 <Tip>
-**Session Continuity**: Sessions are identified purely by name. Using the same `--session` value automatically continues the session—no explicit "create" or "resume" needed.
+Your coding agent can manage sessions too. Tell it: "Run the evals with session name `rag-fix` and run name `before`" — then after changes, "Rerun with run name `after` and compare the results."
 </Tip>
-
-<Warning>
-**Storage**: Session metadata is stored in each run's JSON file. There's no separate session file—sessions are virtual groupings based on the `session_name` field.
-</Warning>

--- a/docs/guides/web-ui.mdx
+++ b/docs/guides/web-ui.mdx
@@ -1,13 +1,18 @@
 ---
 title: Web UI
-description: Run evals and review results in your browser
+description: Your dashboard for running evals and analyzing results
 ---
 
-Start the web UI with `ezvals serve`:
+The Web UI is your primary interface for interacting with evaluations. Start it with:
 
 ```bash
 ezvals serve evals.py
+
+# Or serve an entire directory
+ezvals serve evals/
 ```
+
+This opens a browser at `http://127.0.0.1:8000` with a dashboard for running, reviewing, and comparing evaluations.
 
 <img
   className="block dark:hidden"
@@ -20,129 +25,109 @@ ezvals serve evals.py
   alt="EZVals Web UI"
 />
 
-## How It Works
+## Running Evals
 
-The UI discovers all `@eval` decorated functions in your file but doesn't run them until you click **Run**. Results stream in real-time as each evaluation completes.
+The UI discovers all `@eval`-decorated functions in your files but doesn't run them until you click **Run**. Results stream in real-time as each evaluation completes.
 
-Results are saved to `.ezvals/runs/` as JSON files. The UI loads from `latest.json` by default, which is a copy of the most recent run.
+| Action | How |
+|---|---|
+| **Run All** | Click play with nothing selected |
+| **Run Selected** | Check specific rows, then click play |
+| **Stop** | Cancel pending and running evals mid-run |
 
-## Results Storage
+## Reviewing Results
 
-```
-.ezvals/
-├── runs/
-│   ├── gpt5-baseline_2024-01-15T10-30-00Z.json
-│   ├── swift-falcon_2024-01-15T14-45-00Z.json
-│   └── latest.json
-└── ezvals.json  # Configuration
-```
+Click any function name to open the detail view. Here you can see:
 
-Each run file includes session metadata:
+- **Input/Output/Reference** — The full data for each evaluation
+- **Scores** — All scoring metrics with pass/fail and numeric values
+- **Latency** — How long the evaluation took
+- **Error details** — Full error messages for failed evals
+- **Chat rendering** — If your input/output contains message arrays (OpenAI, Anthropic format), they auto-render as a chat conversation. Toggle between Pretty and Raw views.
 
-```json
-{
-  "session_name": "model-upgrade",
-  "run_name": "gpt5-baseline",
-  "run_id": "2024-01-15T10-30-00Z",
-  "total_evaluations": 50,
-  "total_passed": 45,
-  "results": [...]
-}
-```
-
-## Run Controls
-
-- **Run Selected**: Check rows, then click play to rerun only those evaluations
-- **Run All**: With nothing selected, click play to rerun everything
-- **Stop**: Cancel pending and running evaluations mid-run
-
-## Detail Page
-
-Click a function name to open the full-page detail view with its own URL (`/runs/{run_id}/results/{index}`). Navigate between results with arrow keys (↑/↓) or press Escape to return to the table.
-
-When `input`, `output`, `reference`, or trace `messages` contain chat-style message arrays (OpenAI, Anthropic, or similar `{role, content}` variants), the detail view auto-renders them in a chat-style layout. Use the **Pretty**/**Raw** toggle in each section to switch between formatted message boxes and raw JSON.
+Navigate between results with **arrow keys** (up/down) or press **Escape** to return to the table.
 
 ## Inline Editing
 
-In the detail page, you can edit:
-- **Dataset**: Reassign to different dataset
-- **Labels**: Add or remove labels
-- **Scores**: Adjust scores or add new ones
-- **Annotations**: Add notes for review
+From the detail view, you can edit results directly:
 
-Changes are saved to the results file.
+- **Dataset** — Reassign to a different dataset
+- **Labels** — Add or remove labels
+- **Scores** — Adjust scores or add new ones
+- **Annotations** — Add notes for review or team discussion
 
-## Export
+Changes save automatically to the results JSON file.
 
-Click the download icon in the header to open the export menu:
+## Filtering
 
-| Format | Type | Description |
-|--------|------|-------------|
-| JSON | Raw | Full results file as-is |
-| CSV | Raw | All results in flat CSV format |
-| Markdown | Filtered | ASCII bar charts + table with current filters applied |
-| PNG | Visual | Chart image with stats bars, metrics, and branding |
-
-**Filtered exports** respect:
-- Active search and filters (only visible rows are exported)
-- Column visibility (hidden columns are excluded)
-- Computed stats from filtered results
-
-PNG export opens a preview modal where you can save or copy the image. Use the options button to edit the title, tune score colors, toggle footer metrics, and in comparison mode rename/reorder runs before exporting.
-
-Markdown uses ASCII progress bars with color indicators:
-
-```
-| Metric | Progress | Score |
-|--------|----------|-------|
-| **accuracy** | ████████████████░░░░ 🟢 | 82% (41/50) |
-| **quality** | ██████████████░░░░░░ 🟡 | 70% (avg: 0.70) |
-```
-
-## Keyboard Shortcuts
-
-| Key | Action |
-|-----|--------|
-| `r` | Refresh results |
-| `e` | Export menu |
-| `f` | Focus filter |
-| `↑/↓` | Navigate results (detail page) |
-| `Esc` | Back to table |
-
-## Custom Port
+Focus on what matters:
 
 ```bash
-ezvals serve evals.py --port 3000
+# Start with filters from the CLI
+ezvals serve evals.py --dataset sentiment --label production
+
+# Or filter interactively in the UI
 ```
 
-## Loading Previous Runs
+Press **f** to focus the filter bar. Filter by dataset, labels, pass/fail status, or search across function names and results.
 
-To view or continue a previous run, pass the run JSON file directly:
+## Comparing Runs
 
-```bash
-ezvals serve .ezvals/sessions/default/sleek-wolf_1705312200.json
-```
-
-The UI loads with that run's results. If the original eval file still exists, you can rerun evaluations normally. If the source file was moved or deleted, the UI shows a warning and works in view-only mode.
-
-This is useful for:
-- Reviewing historical results
-- Continuing an interrupted session
-- Sharing runs between machines (copy the JSON file)
-
-## Comparison Mode
-
-Compare results across multiple runs side-by-side. When you have 2+ runs in a session:
+When you have multiple runs (from different sessions or iterations), compare them side-by-side:
 
 1. Click **+ Compare** in the stats bar
 2. Select runs from the dropdown (up to 4)
 3. View grouped bar charts showing metrics across runs
 4. Compare outputs in a table with per-run columns
 
-Each run gets a color-coded chip. The chart shows pass rates and latency for each run. The table aligns results by function name and dataset, making it easy to spot regressions or improvements.
+Each run gets a color-coded chip. The chart shows pass rates and latency across runs. Results are aligned by function name and dataset so you can spot regressions and improvements at a glance.
 
-To exit comparison mode, click the × on run chips until only one remains.
+## Exporting Results
 
-## Run Selector
+Click the download icon to export:
 
-When multiple runs exist in a session, the run name becomes a dropdown. Select past runs to view their results. The dropdown shows run names with timestamps.
+| Format | What You Get |
+|---|---|
+| **JSON** | Full results file — all data, no filtering |
+| **CSV** | Flat table of all results |
+| **Markdown** | ASCII bar charts and table with current filters applied |
+| **PNG** | Chart image with stats, metrics, and branding |
+
+Markdown and PNG exports respect your current filters and column visibility. PNG opens a preview where you can customize the title, score colors, and footer metrics before saving.
+
+## Loading Previous Runs
+
+View historical results by passing a run file directly:
+
+```bash
+ezvals serve .ezvals/runs/gpt5-baseline_2024-01-15T10-30-00Z.json
+```
+
+If the original eval file still exists, you can rerun evaluations. Otherwise the UI works in view-only mode.
+
+## Sessions in the UI
+
+When multiple runs exist in a session, the run name becomes a dropdown. Select past runs to browse their results and use comparison mode to see them side-by-side. See [Sessions & Runs](/guides/sessions) for details on organizing runs.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|---|---|
+| `r` | Refresh results |
+| `e` | Export menu |
+| `f` | Focus filter bar |
+| `Up/Down` | Navigate results (detail view) |
+| `Esc` | Back to table |
+
+## Configuration
+
+```bash
+# Custom port
+ezvals serve evals.py --port 3000
+
+# Start with auto-run
+ezvals serve evals.py --run
+
+# Disable auto-open browser
+ezvals serve evals.py --no-open
+```

--- a/docs/guides/working-with-your-agent.mdx
+++ b/docs/guides/working-with-your-agent.mdx
@@ -1,0 +1,154 @@
+---
+title: Working with Your Agent
+description: How to collaborate with your coding agent on evaluations
+---
+
+EZVals is designed so that your coding agent does most of the implementation work. This guide covers how to set up that workflow and get the most out of it.
+
+## Setup
+
+### 1. Install EZVals
+
+```bash
+pip install ezvals
+```
+
+### 2. Install the Agent Skill
+
+```bash
+ezvals skills add
+```
+
+This installs eval-specific guidance into your agent's skill directory. The skill teaches your agent:
+
+- EZVals API and patterns
+- Best practices for eval design
+- Grading strategies (code vs model vs human)
+- Patterns for different agent types (coding, conversational, research)
+
+Your agent will reference this skill automatically when you ask about evals.
+
+### 3. Verify
+
+```bash
+ezvals skills doctor
+```
+
+Confirms the skill is installed and your agent can find it.
+
+## Prompting Your Agent
+
+Here are effective ways to ask your agent for eval work:
+
+### Starting from Scratch
+
+```
+"I have a customer support agent in support_agent.py. Write evals that test:
+ - Correct identification of customer issues
+ - Following our refund policy (7-day window, receipt required)
+ - Appropriate escalation to human agents for complex issues"
+```
+
+Your agent will create an eval file with `@eval`-decorated functions, test cases, and assertions based on your requirements.
+
+### Adding to Existing Evals
+
+```
+"Add edge cases to the refund evals — test what happens when the customer
+ doesn't have a receipt, when the item is past the return window, and when
+ they request a partial refund"
+```
+
+### Running and Analyzing
+
+```
+"Run the support evals and tell me what's failing"
+```
+
+```
+"Run the evals with --session v2-testing and compare to the previous run"
+```
+
+```
+"The tone evals are failing — look at the results and suggest prompt changes"
+```
+
+### Iterating
+
+```
+"Fix the issues you found and rerun the evals to confirm"
+```
+
+```
+"The hallucination scores are too low. Look at the failing cases and
+ improve the retrieval pipeline"
+```
+
+## The Agent's Workflow
+
+When your agent works with EZVals, it typically follows this pattern:
+
+```
+1. Read the eval file to understand existing evals
+2. Write or modify eval functions
+3. Run: ezvals run evals.py --verbose
+4. Read the JSON results
+5. Analyze failures and suggest/implement fixes
+6. Rerun to verify
+```
+
+The key insight is that your agent reads the same JSON result files that the Web UI displays. It can parse inputs, outputs, scores, error messages, and latency data programmatically.
+
+## Agent + Web UI Workflow
+
+The most effective workflow combines both interfaces:
+
+1. **Agent writes evals** based on your description
+2. **Agent runs evals** via CLI and reports initial results
+3. **You review in the Web UI** — browse results visually, check specific cases, compare runs
+4. **You give feedback** — "The tone scoring is too lenient" or "Add more edge cases for X"
+5. **Agent iterates** — fixes scoring, adds cases, reruns
+6. **You confirm in the Web UI** — final review of improved results
+
+This loop lets you stay in the driver's seat on quality decisions while your agent handles the implementation.
+
+## Tips
+
+### Be Specific About Criteria
+
+Instead of "test my agent," describe the specific behaviors you care about:
+
+```
+# Vague — agent has to guess what matters
+"Write evals for my agent"
+
+# Specific — agent knows exactly what to test
+"Write evals for my RAG agent that check:
+ 1. Retrieved documents are relevant to the query
+ 2. The response doesn't hallucinate facts not in the documents
+ 3. The response cites specific documents when making claims"
+```
+
+### Let the Agent Handle Technical Decisions
+
+You don't need to specify whether to use assertions vs `store()`, or how to structure the eval file. Your agent has the skill and knows EZVals patterns. Focus on **what** to test, not **how** to write the code.
+
+### Use Sessions for Tracking
+
+When you're iterating, always use session names so you can compare:
+
+```
+"Run the evals with --session rag-improvement --run-name v1"
+```
+
+This makes it easy to track progress across multiple iterations in the Web UI.
+
+### Review Before Trusting
+
+Your agent's analysis is useful but not infallible. Use the Web UI to spot-check results, especially early on. Look at the actual inputs and outputs to make sure:
+
+- The evals are testing what you intended
+- The scoring criteria make sense
+- Edge cases aren't being missed
+
+As your eval suite matures, you can rely more heavily on automated results and agent analysis.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -14,9 +14,64 @@ description: Unit Testing for LLMs and Agents
   alt="EZVals Hero"
 />
 
-EZVals is a lightweight, code-first evaluation framework for testing AI agents and LLM applications. Inspired by Pytest and LangSmith, EZVals lets you
-write evaluations like you write unit tests!
+EZVals is a lightweight evaluation framework for testing AI agents and LLM applications. Write evals as Python functions, run them from a web dashboard or the CLI, and let your coding agent handle the implementation details.
 
+<CardGroup cols={2}>
+  <Card title="For You" icon="user">
+    A visual dashboard to run evals, analyze results, compare runs, and track progress over time.
+  </Card>
+  <Card title="For Your Agent" icon="robot">
+    A compact CLI and SDK that your coding agent uses to write, run, and iterate on evals autonomously.
+  </Card>
+</CardGroup>
+
+## How It Works
+
+EZVals is designed around a simple loop:
+
+```
+You describe what to evaluate
+        ↓
+Your coding agent writes the eval code
+        ↓
+You run evals from the Web UI (or the agent runs them via CLI)
+        ↓
+Review results, compare runs, iterate
+```
+
+You focus on **what** to test and **whether results look right**. Your agent focuses on **how** to write the eval code.
+
+### The Web UI
+
+Run evals, review results, and do deep analysis — all from a local dashboard:
+
+<img
+  className="block dark:hidden"
+  src="/assets/ui-screenshot-light.png"
+  alt="EZVals Web UI"
+/>
+<img
+  className="hidden dark:block"
+  src="/assets/ui-screenshot-dark.png"
+  alt="EZVals Web UI"
+/>
+
+Filter by dataset or label, run individual evals or entire suites, compare runs side-by-side, and export results. All data stays local as JSON files.
+
+### Agent Mode
+
+Your coding agent can run evals headlessly and analyze the results:
+
+```bash
+ezvals run evals.py --session my-experiment --verbose
+```
+
+<img
+  src="/assets/terminal-output.svg"
+  alt="Terminal output showing eval results"
+/>
+
+The agent reads the JSON output, identifies failures, fixes the underlying code, and reruns — without you writing a single eval function by hand.
 
 ## Install
 
@@ -34,135 +89,47 @@ pip install ezvals
 poetry add ezvals --group dev
 ```
 
-<CardGroup cols={2}>
-  <Card title="Version-Control" icon="code-branch">
-    Aligned with your local env. Branch to experiment!
-  </Card>
-  <Card title="Pytest-Inspired" icon="flask-vial">
-    Use `assert`, `cases`, and simple decorators.
-  </Card>
-  <Card title="Full Flexibility" icon="sliders">
-    Use the same evaluator across a dataset or case-by-case
-  </Card>
-  <Card title="Agent-Friendly" icon="robot">
-    Powerful and compact CLI and SDK for your coding agent to use
-  </Card>
-</CardGroup>
-
-
 </CodeGroup>
 
-## Quick Example
-
-Evaluating a simple sentiment analyzer against a ground truth dataset:
-
-```python
-from ezvals import eval, EvalContext
-
-@eval(
-  input="I love this product!",  # Prompt
-  reference="positive",          # Ground Truth
-  dataset="sentiment"            # Label for filtering
-)
-async def test_sentiment_analysis(ctx: EvalContext):
-    # Run test and store output in context
-    ctx.output = await analyze_sentiment(ctx.input)
-
-    # Evaluate!
-    assert ctx.output == ctx.reference, f"Expected {ctx.reference}, got {ctx.output}"
-```
-
-Or use `cases=` to apply eval to a dataset:
-
-```python
-@eval(
-  dataset="sentiment",
-  cases=[
-      {"input": "I love this product!", "reference": "positive"},
-      {"input": "This is terrible", "reference": "negative"},
-      {"input": "It's okay I guess", "reference": "neutral"},
-  ],
-)
-async def test_sentiment_batch(ctx: EvalContext):
-    # Case data is injected into the ctx
-    ctx.output = await analyze_sentiment(ctx.input)
-
-    assert ctx.output == ctx.reference, f"Expected {ctx.reference}, got {ctx.output}"
-```
-
-Start the web UI to run evals and review results:
-
-```bash
-ezvals serve sentiment_evals.py
-
-# Or run all in a dir
-ezvals serve evals/
-```
-
-### Web UI
-
-EZVals spins up a local Web UI that makes it easy to filter, run, and rerun evals. Do deep analysis on the results
-
-<img
-  className="block dark:hidden"
-  src="/assets/ui-screenshot-light.png"
-  alt="EZVals Web UI"
-/>
-<img
-  className="hidden dark:block"
-  src="/assets/ui-screenshot-dark.png"
-  alt="EZVals Web UI"
-/>
-
-All results are stored locally in a `.json` file for further analysis.
-
-## Agent Mode
-
-The CLI and SDK make it easy for your coding agent to run, analyze, and iterate on the evals!
-
-> Can you run `test_sentiment_batch` evals and tell me why the scores are so low?
-
-Your coding agent would run:
-
-```bash
-ezvals run sentiment_evals.py::test_sentiment_batch --session sentiment-failed-results
-
-// Eval results saved to ./ezvals/cool-cloud-2025.json
-```
-
-The agent could review the json results before presenting a solution to you. It could even implement that solution and rerun the evals to compare
-before and after!
-
-### Skills Setup
-
-Install the EZVals skill so your coding agent has eval-specific guidance:
+Then install the agent skill so your coding agent knows how to work with EZVals:
 
 ```bash
 ezvals skills add
 ```
 
-For everything else (verification, updates, global install, and marketplace install), see the [Agent Skill guide](/guides/agent-skill).
+This gives your agent (Claude Code, Cursor, Codex, etc.) eval-specific guidance and best practices. See the [Agent Skill guide](/guides/agent-skill) for details.
 
-## Existing eval frameworks are frustrating:
+## What Makes EZVals Different
 
 <CardGroup cols={3}>
-  <Card title="Too Opinionated" icon="lock" color="#9ca3af">
-    One function per dataset, rigid patterns. No way to run different logic per
-    test case.
+  <Card title="Code-First" icon="code">
+    Evals are Python functions in your repo. Version-controlled, branch-able, diff-able.
   </Card>
-  <Card title="Cloud-Based" icon="cloud" color="#9ca3af">
-    Datasets in the cloud. No version control. Code and data live in different
-    places.
+  <Card title="Agent-Friendly" icon="terminal">
+    A CLI and SDK designed for coding agents to run evals, parse results, and iterate autonomously.
   </Card>
-  <Card title="UI-Based" icon="display" color="#9ca3af">
-    Your coding agent can't run evals, analyze results, or iterate on datasets.
+  <Card title="Flexible Scoring" icon="chart-simple">
+    Use simple assertions, numeric scores, or custom evaluators. Mix and match per eval.
   </Card>
 </CardGroup>
 
-**Pytest isn't the answer either.** Tests are pass/fail—evals are for _analysis_. You want to see all results, latency, cost, comparisons over time. Pytest doesn't do that.
+### Why not existing frameworks?
 
-**EZVals is different:** minimal, flexible, agent-friendly. Everything lives locally as code and JSON.
+<AccordionGroup>
+  <Accordion title="Too opinionated">
+    Many frameworks force one function per dataset with rigid patterns. EZVals lets you run different logic per test case, share targets across evals, and structure things however makes sense.
+  </Accordion>
+  <Accordion title="Cloud-based">
+    Datasets in the cloud means no version control, and code and data live in different places. EZVals keeps everything local — evals are code, results are JSON files.
+  </Accordion>
+  <Accordion title="UI-only">
+    If your eval framework lives behind a web UI, your coding agent can't run evals, analyze results, or iterate on datasets. EZVals has both a Web UI for you and a CLI for your agent.
+  </Accordion>
+  <Accordion title="What about pytest?">
+    Tests are pass/fail — evals are for analysis. You want to see all results, latency, comparisons over time. Pytest doesn't store results, doesn't give you a dashboard, and doesn't do run comparison.
+  </Accordion>
+</AccordionGroup>
 
 <Card title="Ready to start?" icon="play" href="/quickstart">
-  Follow our quickstart guide to set up EZVals in under 5 minutes.
+  Install EZVals and run your first evaluation.
 </Card>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -38,39 +38,58 @@
       "pages": ["introduction", "quickstart"]
     },
     {
-      "group": "Examples",
+      "group": "Concepts",
       "pages": [
-        "examples/granular-evals",
-        "examples/rag-agent"
-      ]
-    },
-    {
-      "group": "Core Concepts",
-      "pages": [
-        "core-concepts/eval-context",
-        "core-concepts/decorators",
-        "core-concepts/scoring",
-        "core-concepts/parametrize"
+        "concepts/architecture",
+        "concepts/workflow",
+        "concepts/evaluation-best-practices"
       ]
     },
     {
       "group": "Guides",
       "pages": [
-        "guides/file-defaults",
-        "guides/patterns",
         "guides/web-ui",
         "guides/sessions",
-        "guides/evaluators",
+        "guides/working-with-your-agent",
         "guides/agent-skill"
       ]
     },
     {
-      "group": "API Reference",
+      "group": "Use Cases",
       "pages": [
-        "api-reference/cli",
-        "api-reference/http-api",
-        "api-reference/eval-result",
-        "api-reference/score"
+        "examples/rag-agent",
+        "examples/granular-evals"
+      ]
+    },
+    {
+      "group": "Technical Reference",
+      "pages": [
+        {
+          "group": "Core Concepts",
+          "pages": [
+            "core-concepts/eval-context",
+            "core-concepts/decorators",
+            "core-concepts/scoring",
+            "core-concepts/parametrize"
+          ]
+        },
+        {
+          "group": "Patterns & Guides",
+          "pages": [
+            "guides/patterns",
+            "guides/file-defaults",
+            "guides/evaluators"
+          ]
+        },
+        {
+          "group": "API Reference",
+          "pages": [
+            "api-reference/cli",
+            "api-reference/http-api",
+            "api-reference/eval-result",
+            "api-reference/score"
+          ]
+        }
       ]
     },
     {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,101 +1,60 @@
 ---
-title: Quickstart
-description: Get up and running with EZVals in under 5 minutes
+title: Setup & First Run
+description: Install EZVals and run your first evaluation
 ---
 
-## Your First Evaluation
+## Install
 
-Create a file called `evals.py`:
+<CodeGroup>
 
-### Target function
+```bash uv
+uv add ezvals --dev
+```
 
-The target function represents the thing you are evaluating. If you are evaluating an agent, your target function would run
-the agent and return the results. If you are evaluating a single LLM call, the target would just invoke the LLM and return those results.
+```bash pip
+pip install ezvals
+```
 
-Using a `target` function function comes with the added benefits of:
+```bash poetry
+poetry add ezvals --group dev
+```
 
-- **Latency Tracking** - Target function latency will be tracked separately from evaluation latency and is handled automatically
-- **Reusability** - Write one target function and reuse it across many evals
-- **Prepopulates Context** - Useful for injecting data into the context (similar to `beforeEach`)
+</CodeGroup>
+
+## Set Up the Agent Skill
+
+Install the skill so your coding agent knows how to write evals:
+
+```bash
+ezvals skills add
+```
+
+This works with Claude Code, Cursor, Codex, and other agents. The skill gives your agent EZVals-specific guidance, patterns, and best practices.
+
+## Write Your First Eval
+
+Create a file called `evals.py`. You can write this yourself or ask your coding agent:
+
+> "Write an eval that tests my agent's greeting response"
+
+Here's what a basic eval looks like:
 
 ```python
 from ezvals import eval, EvalContext
 
-async def my_agent_target(ctx: EvalContext):
-    # Run your agent using your own custom logic.
-    # Use the injected `input` from the evals.
-    agent_results = run_agent(ctx.input)
-
-    # Inject output into context using store()
-    ctx.store(output=agent_results["content"])
-
-    # You can also inject anything you might need in other tests
-    # For example, we can inject the RAG search results for future RAG evals
-    ctx.my_rag_search_results = agent_results["documents"]
-```
-
-Now that we have a universal target function, we can point our evals at it:
-
-```python
-@eval(
-  input="Hello, how are you?",
-  target=my_agent_target
-)
+@eval(input="Hello, how are you?", dataset="greetings")
 async def test_greeting(ctx: EvalContext):
-    """Evaluate the agent's greeting ability"""
-
-    # ctx is already populated so we can just focus on evaluation logic
-    # Use assertions to score - just like pytest!
+    ctx.output = await my_agent(ctx.input)
     assert "hello" in ctx.output.lower(), "Response should contain a greeting"
 ```
 
-That's it! Assertions work like pytest - if they all pass, your eval passes. If they fail, the assertion message becomes the failure reason.
+The `@eval` decorator marks a function as an evaluation. Assertions work like pytest — pass means pass, fail captures the message for analysis.
 
-Non-assertion errors are caught as errors.
-
-## Run Your Evaluations
-
-Start the web UI to run evals and review results:
-
-```bash
-ezvals serve evals.py
-```
-
-This opens a browser at `http://127.0.0.1:8000` where you can:
-
-- Run, filter, and rerun specific evals
-- Review eval results for analysis
-- Annotate results inline
-- Export results to JSON or CSV
-
-<img src="/assets/ui-screenshot.png" alt="EZVals Web UI" />
-
-### Agent Mode
-
-When coding agent needs to run evals programmatically, use `run`:
-
-```bash
-ezvals run evals.py
-```
-
-This outputs compact results to stdout—perfect for when an AI agent needs to parse results.
-
-<img
-  src="/assets/terminal-output.svg"
-  alt="Terminal output showing eval results"
-/>
-
-## Add More Test Cases
-
-Use `cases=` to generate multiple evaluations from one function:
+For testing multiple inputs, use `cases`:
 
 ```python
-from ezvals import eval, EvalContext
-
 @eval(
-  dataset="greetings", 
-  labels=["production"],
-  target=run_tone_agent,
+  dataset="greetings",
   cases=[
       {"input": "Hello!", "reference": "friendly"},
       {"input": "I need help urgently", "reference": "helpful"},
@@ -103,28 +62,54 @@ from ezvals import eval, EvalContext
   ],
 )
 async def test_response_tone(ctx: EvalContext):
-    assert ctx.output == ctx.reference, f"Expected {ctx.reference} tone, got {ctx.output}"
+    ctx.output = await classify_tone(ctx.input)
+    assert ctx.output == ctx.reference
 ```
 
-Cases are list-of-dict overrides for `@eval` fields. Put any custom data inside `input` (e.g., a dict) and read it from `ctx.input`.
+## Run from the Web UI
 
-## Track Progress with Sessions
-
-Use sessions to group related runs together—useful for comparing models, tracking iterations, or A/B testing:
+Start the dashboard:
 
 ```bash
-# Name your session and run
-ezvals serve evals.py --session model-upgrade --run-name baseline
-
-# Continue the session with another run
-ezvals serve evals.py --session model-upgrade --run-name after-tuning
+ezvals serve evals.py
 ```
 
-Results are saved to `.ezvals/runs/` with session metadata, so you can compare runs over time.
+This opens a browser at `http://127.0.0.1:8000` where you can run evals, view results, and drill into details.
 
-## Configuration with ezvals.json
+<img
+  className="block dark:hidden"
+  src="/assets/ui-screenshot-light.png"
+  alt="EZVals Web UI"
+/>
+<img
+  className="hidden dark:block"
+  src="/assets/ui-screenshot-dark.png"
+  alt="EZVals Web UI"
+/>
 
-Create a `ezvals.json` in your project root to set defaults:
+## Run from the CLI
+
+For your coding agent (or CI/CD), use headless mode:
+
+```bash
+# Run all evals
+ezvals run evals.py
+
+# Run a specific eval
+ezvals run evals.py::test_greeting
+
+# Filter by dataset
+ezvals run evals.py --dataset greetings
+
+# Run with a session name for tracking
+ezvals run evals.py --session my-experiment --run-name baseline
+```
+
+Results are saved to `.ezvals/runs/` as JSON, ready for analysis or comparison.
+
+## Configuration
+
+Create `ezvals.json` in your project root to set defaults:
 
 ```json
 {
@@ -133,38 +118,19 @@ Create a `ezvals.json` in your project root to set defaults:
 }
 ```
 
-This saves you from passing the same flags repeatedly.
-
-## Filter and Run Specific Tests
-
-```bash
-# Run a specific function
-ezvals serve evals.py::test_greeting
-
-# Filter by dataset
-ezvals serve evals.py --dataset greetings
-
-# Filter by labels
-ezvals serve evals.py --label production
-
-# Run with concurrency
-ezvals serve evals.py --concurrency 4
-```
-
-
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="EvalContext" icon="code" href="/core-concepts/eval-context">
-    Learn about the builder pattern that powers EZVals
+  <Card title="Architecture" icon="sitemap" href="/concepts/architecture">
+    Understand how EZVals is structured and how the pieces fit together.
   </Card>
-  <Card title="Decorators" icon="at" href="/core-concepts/decorators">
-    Master the @eval decorator and its options
+  <Card title="The Evaluation Loop" icon="arrows-rotate" href="/concepts/workflow">
+    Learn the evaluate → analyze → iterate workflow.
   </Card>
-  <Card title="Scoring" icon="chart-simple" href="/core-concepts/scoring">
-    Understand flexible scoring systems
+  <Card title="Web UI Guide" icon="display" href="/guides/web-ui">
+    Deep dive into the dashboard features.
   </Card>
-  <Card title="Patterns" icon="diagram-project" href="/guides/patterns">
-    See common evaluation patterns
+  <Card title="Agent Skill" icon="robot" href="/guides/agent-skill">
+    Configure your coding agent for eval workflows.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Rewrite documentation to prioritize developers who use coding agents
rather than developers who handwrite code. The new structure leads with
high-level concepts, visuals, and workflows, then moves detailed
technical reference to the bottom of the navigation.

New pages:
- concepts/architecture: system overview with ASCII diagrams
- concepts/workflow: the evaluate-analyze-iterate loop
- concepts/evaluation-best-practices: how to think about LLM evaluation
- guides/working-with-your-agent: agent collaboration workflows

Rewritten pages:
- introduction: philosophy-first, less code, more visuals
- quickstart: simplified setup-focused flow
- web-ui: screenshots-first visual walkthrough
- sessions: user-focused, removed API endpoint details

Navigation restructured:
1. Getting Started (intro, setup)
2. Concepts (architecture, workflow, best practices)
3. Guides (web UI, sessions, agent workflow, agent skill)
4. Use Cases (RAG agent, granular evals)
5. Technical Reference (core concepts, patterns, API reference)
6. Resources (changelog)

https://claude.ai/code/session_01JXmWgkyh7oopCPE6X6A5WL